### PR TITLE
Add vgm2pcm

### DIFF
--- a/VGMPlay/.gitignore
+++ b/VGMPlay/.gitignore
@@ -1,0 +1,3 @@
+/obj
+/vgm2pcm
+/vgmplay

--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -67,7 +67,6 @@ OBJDIRS = \
 MAINOBJS = \
 	$(OBJ)/VGMPlay.o \
 	$(OBJ)/VGMPlay_AddFmts.o \
-	$(OBJ)/VGMPlayUI.o \
 	$(OBJ)/Stream.o \
 	$(OBJ)/ChipMapper.o \
 	$(OBJ)/utils.o
@@ -136,31 +135,42 @@ EMUOBJS = \
 	$(EMUOBJ)/sn76496_opl.o \
 	$(EMUOBJ)/ym2413hd.o \
 	$(EMUOBJ)/ym2413_opl.o
+VGMPLAY_OBJS = \
+	$(OBJ)/VGMPlayUI.o
+VGM2PCM_OBJS = \
+	$(OBJ)/vgm2pcm.o
+EXTRA_OBJS = $(VGMPLAY_OBJS) $(VGM2PCM_OBJS)
 
 
-all:	vgmplay
+all:	vgmplay vgm2pcm
 
-vgmplay:	$(OBJDIRS) $(EMUOBJS) $(MAINOBJS)
-	@echo Linking ...
-	@$(CC) $(MAINOBJS) $(EMUOBJS) $(LDFLAGS) -o vgmplay
+vgmplay:	$(EMUOBJS) $(MAINOBJS) $(VGMPLAY_OBJS)
+	@echo Linking vgmplay ...
+	@$(CC) $(VGMPLAY_OBJS) $(MAINOBJS) $(EMUOBJS) $(LDFLAGS) -o vgmplay
+	@echo Done.
+
+vgm2pcm:	$(EMUOBJS) $(MAINOBJS) $(VGM2PCM_OBJS)
+	@echo Linking vgm2pcm ...
+	@$(CC) $(VGM2PCM_OBJS) $(MAINOBJS) $(EMUOBJS) $(LDFLAGS) -o vgm2pcm
 	@echo Done.
 
 # compile the chip-emulator c-files
 $(EMUOBJ)/%.o:	$(EMUSRC)/%.c
 	@echo Compiling $< ...
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) $(EMUFLAGS) -c $< -o $@
 
 # compile the main c-files
 $(OBJ)/%.o:	$(SRC)/%.c
 	@echo Compiling $< ...
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) $(MAINFLAGS) -c $< -o $@
-
-$(OBJDIRS):
-	mkdir $@
 
 clean:
 	@echo Deleting object files ...
-	@rm -f $(MAINOBJS) $(EMUOBJS)
+	@rm -f $(MAINOBJS) $(EMUOBJS) $(EXTRA_OBJS)
+	@echo Deleting executable files ...
+	@rm -f vgmplay vgm2pcm
 	@echo Done.
 
 # Thanks to ZekeSulastin and nextvolume for the install and uninstall routines.
@@ -182,4 +192,4 @@ uninstall:
 	rm $(DESTDIR)$(MANPREFIX)/man1/vgmplay.1
 	rm -rf $(DESTDIR)$(PREFIX)/share/vgmplay
 
-.PHONY: clean install uninstall
+.PHONY: all clean install uninstall

--- a/VGMPlay/vgm2pcm.c
+++ b/VGMPlay/vgm2pcm.c
@@ -1,0 +1,86 @@
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include "stdbool.h"
+#include "utils.h"
+#include "VGMPlay.h"
+#include "VGMPlay_Intf.h"
+
+#define SAMPLESIZE sizeof(WAVE_16BS)
+
+UINT8 CmdList[0x100]; // used by VGMPlay.c and VGMPlay_AddFmts.c
+bool ErrorHappened;   // used by VGMPlay.c and VGMPlay_AddFmts.c
+extern VGM_HEADER VGMHead;
+extern UINT32 SampleRate;
+extern UINT32 VGMMaxLoopM;
+extern UINT32 FadeTime;
+extern bool EndPlay;
+
+INLINE int fputBE16(UINT16 Value, FILE* hFile)
+{
+    int RetVal;
+    int ResVal;
+
+    RetVal = fputc((Value & 0xFF00) >> 8, hFile);
+    RetVal = fputc((Value & 0x00FF) >> 0, hFile);
+    ResVal = (RetVal != EOF) ? 0x02 : 0x00;
+    return ResVal;
+}
+
+int main(int argc, char *argv[]) {
+    UINT8 result;
+    WAVE_16BS *sampleBuffer;
+    UINT32 bufferedLength;
+    FILE *outputFile;
+
+    if (argc < 3) {
+        fputs("usage: vgm2pcm vgm_file pcm_file\n", stderr);
+        return 1;
+    }
+
+    VGMPlay_Init();
+    VGMPlay_Init2();
+
+    if (!OpenVGMFile(argv[1])) {
+        fprintf(stderr, "vgm2pcm: error: failed to open vgm_file (%s)\n", argv[1]);
+        return 1;
+    }
+
+    outputFile = fopen(argv[2], "wb");
+    if (outputFile == NULL) {
+        fprintf(stderr, "vgm2pcm: error: failed to open pcm_file (%s)\n", argv[2]);
+        return 1;
+    }
+
+    PlayVGM();
+
+    sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
+    if (sampleBuffer == NULL) {
+        fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+        return 1;
+    }
+
+    while (!EndPlay) {
+        UINT32 bufferSize = SampleRate;
+        bufferedLength = FillBuffer(sampleBuffer, bufferSize);
+        if (bufferedLength) {
+            UINT32 numberOfSamples;
+            UINT32 currentSample;
+            const UINT16* sampleData;
+
+            sampleData = (INT16*)sampleBuffer;
+            numberOfSamples = SAMPLESIZE * bufferedLength / 0x02;
+            for (currentSample = 0x00; currentSample < numberOfSamples; currentSample++) {
+                fputBE16(sampleData[currentSample], outputFile);
+            }
+        }
+    }
+
+    StopVGM();
+
+    CloseVGMFile();
+
+    VGMPlay_Deinit();
+
+    return 0;
+}


### PR DESCRIPTION
**vgm2pcm** is a program that converts a VGM file to the L16 format, as described in RFC 3551. It takes 2 arguments: the input VGM file and the output file. The output file may be a named pipe (FIFO), which makes it possible to use vgm2pcm as a transcoding agent in MediaTomb.

Makefile was modified to support building vgm2pcm from the same objects vgmplay uses. There is no longer a rule to make directories: they are created automatically if necessary when building objects. The reason is that when running `make` to build vgmplay and vgm2pcm at the same time, `obj/vgm2pcm.o` was created after vgmplay, and if `make` is run again, make detects that vgmplay needs to be rebuilt because the `obj` directory was modified.