### PR TITLE
Vgm2pcm wav support

### DIFF
--- a/VGMPlay/vgm2pcm.c
+++ b/VGMPlay/vgm2pcm.c
@@ -70,10 +70,10 @@ void usage(const char *name) {
 #ifdef VGM2PCM_HAS_GETOPT
     fprintf(stderr, "\n"
                     "Default options:\n"
-                    "--loop-count %d\n"
-                    "--fade-ms %d\n"
-                    "--format l16\n"
-                    "\n", VGMMaxLoop, FadeTime);
+                    "--loop-count 2\n"
+                    "--fade-ms 5000\n"
+                    "--format L16\n"
+                    "\n");
 #endif
 }
 
@@ -120,11 +120,11 @@ int main(int argc, char *argv[]) {
                 //fprintf(stderr, "Setting fade-out time in milliseconds to %u\n", FadeTime);
                 break;
             case 't':
-                if (stricmp(optarg, "l16") == 0) {
+                if (strcasecmp(optarg, "l16") == 0) {
                     outputFormat = L16;
-                } else if (stricmp(optarg, "wav") == 0) {
+                } else if (strcasecmp(optarg, "wav") == 0) {
                     outputFormat = WAV;
-                } else if (stricmp(optarg, "lwav") == 0) {
+                } else if (strcasecmp(optarg, "lwav") == 0) {
                     outputFormat = LWAV;
                 } else {
                     fprintf(stderr, "Invalid output format: %s\n", optarg);

--- a/VGMPlay/vgm2pcm.c
+++ b/VGMPlay/vgm2pcm.c
@@ -158,7 +158,9 @@ int main(int argc, char *argv[]) {
     }
 
     if (argv[2][0] == '-' && argv[2][1] == '\0') {
+#ifdef O_BINARY
         setmode(fileno(stdout), O_BINARY);
+#endif
         outputFile = stdout;
     } else {
         outputFile = fopen(argv[2], "wb");


### PR DESCRIPTION
This patch extends vgm2pcm to support the export of PCM WAV files, with or without a "smpl" chunk to denote the start and end of the looping section of the VGM. It also adds command-line options to change the amount of loops played and amount of fade-out time at the end, and allows the use of standard output instead of a file (although using standard output with WAV format will give a non-conforming file, using -1 for the length of the RIFF and of the data chunk, since stdout is not seekable.)
If it makes more sense to have a separate vgm2wav application, I can do that instead.