### PR TITLE
vgm2wav

### DIFF
--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -151,10 +151,12 @@ VGMPLAY_OBJS = \
 	$(OBJ)/VGMPlayUI.o
 VGM2PCM_OBJS = \
 	$(OBJ)/vgm2pcm.o
-EXTRA_OBJS = $(VGMPLAY_OBJS) $(VGM2PCM_OBJS)
+VGM2WAV_OBJS = \
+	$(OBJ)/vgm2wav.o
+EXTRA_OBJS = $(VGMPLAY_OBJS) $(VGM2PCM_OBJS) $(VGM2WAV_OBJS)
 
 
-all:	vgmplay vgm2pcm
+all:	vgmplay vgm2pcm vgm2wav
 
 vgmplay:	$(EMUOBJS) $(MAINOBJS) $(VGMPLAY_OBJS)
 	@echo Linking vgmplay ...
@@ -164,6 +166,11 @@ vgmplay:	$(EMUOBJS) $(MAINOBJS) $(VGMPLAY_OBJS)
 vgm2pcm:	$(EMUOBJS) $(MAINOBJS) $(VGM2PCM_OBJS)
 	@echo Linking vgm2pcm ...
 	@$(CC) $(VGM2PCM_OBJS) $(MAINOBJS) $(EMUOBJS) $(LDFLAGS) -o vgm2pcm
+	@echo Done.
+
+vgm2wav:	$(EMUOBJS) $(MAINOBJS) $(VGM2WAV_OBJS)
+	@echo Linking vgm2wav ...
+	@$(CC) $(VGM2WAV_OBJS) $(MAINOBJS) $(EMUOBJS) $(LDFLAGS) -o vgm2wav
 	@echo Done.
 
 # compile the chip-emulator c-files
@@ -182,7 +189,7 @@ clean:
 	@echo Deleting object files ...
 	@rm -f $(MAINOBJS) $(EMUOBJS) $(EXTRA_OBJS)
 	@echo Deleting executable files ...
-	@rm -f vgmplay vgm2pcm
+	@rm -f vgmplay vgm2pcm vgm2wav
 	@echo Done.
 
 # Thanks to ZekeSulastin and nextvolume for the install and uninstall routines.

--- a/VGMPlay/vgm2wav.c
+++ b/VGMPlay/vgm2wav.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "chips/mamedef.h"
+#include "stdbool.h"
+#include "VGMPlay.h"
+#include "VGMPlay_Intf.h"
+
+#define SAMPLESIZE sizeof(WAVE_16BS)
+
+UINT8 CmdList[0x100]; // used by VGMPlay.c and VGMPlay_AddFmts.c
+bool ErrorHappened;   // used by VGMPlay.c and VGMPlay_AddFmts.c
+extern VGM_HEADER VGMHead;
+extern UINT32 SampleRate;
+extern UINT32 VGMMaxLoopM;
+extern UINT32 FadeTime;
+extern bool EndPlay;
+
+INLINE int fputBE16(UINT16 Value, FILE* hFile)
+{
+    int RetVal;
+    int ResVal;
+
+    RetVal = fputc((Value & 0xFF00) >> 8, hFile);
+    RetVal = fputc((Value & 0x00FF) >> 0, hFile);
+    ResVal = (RetVal != EOF) ? 0x02 : 0x00;
+    return ResVal;
+}
+
+int main(int argc, char *argv[]) {
+    UINT8 result;
+    WAVE_16BS *sampleBuffer;
+    UINT32 bufferedLength;
+    FILE *outputFile;
+
+    if (argc < 3) {
+        fputs("usage: vgm2pcm vgm_file pcm_file\n", stderr);
+        return 1;
+    }
+
+    VGMPlay_Init();
+    VGMPlay_Init2();
+
+    if (!OpenVGMFile(argv[1])) {
+        fprintf(stderr, "vgm2pcm: error: failed to open vgm_file (%s)\n", argv[1]);
+        return 1;
+    }
+
+    outputFile = fopen(argv[2], "wb");
+    if (outputFile == NULL) {
+        fprintf(stderr, "vgm2pcm: error: failed to open pcm_file (%s)\n", argv[2]);
+        return 1;
+    }
+
+    PlayVGM();
+
+    sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
+    if (sampleBuffer == NULL) {
+        fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+        return 1;
+    }
+
+    while (!EndPlay) {
+        UINT32 bufferSize = SampleRate;
+        bufferedLength = FillBuffer(sampleBuffer, bufferSize);
+        if (bufferedLength) {
+            UINT32 numberOfSamples;
+            UINT32 currentSample;
+            const UINT16* sampleData;
+
+            sampleData = (INT16*)sampleBuffer;
+            numberOfSamples = SAMPLESIZE * bufferedLength / 0x02;
+            for (currentSample = 0x00; currentSample < numberOfSamples; currentSample++) {
+                fputBE16(sampleData[currentSample], outputFile);
+            }
+        }
+    }
+
+    StopVGM();
+
+    CloseVGMFile();
+
+    VGMPlay_Deinit();
+
+    return 0;
+}

--- a/VGMPlay/vgm2wav.c
+++ b/VGMPlay/vgm2wav.c
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of VGMPlay <https://github.com/vgmrips/vgmplay>
+ *
+ *  (c)2015 libertyernie <maybeway36@gmail.com>
+ *  Based on vgm2pcm.c:
+ *    (c)2015 Francis Gagné <fragag1@gmail.com>
+ *    (c)2015 Valley Bell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/VGMPlay/vgm2wav.c
+++ b/VGMPlay/vgm2wav.c
@@ -3,6 +3,14 @@
 #include <string.h>
 #include <wchar.h>
 
+#include <fcntl.h>
+
+#ifndef _MSC_VER
+// This turns command line options on (using getopt.h) unless you are using MSVC / Visual Studio, which doesn't have it.
+#define VGM2PCM_HAS_GETOPT
+#include <getopt.h>
+#endif
+
 #include "chips/mamedef.h"
 #include "stdbool.h"
 #include "VGMPlay.h"
@@ -14,75 +22,250 @@ UINT8 CmdList[0x100]; // used by VGMPlay.c and VGMPlay_AddFmts.c
 bool ErrorHappened;   // used by VGMPlay.c and VGMPlay_AddFmts.c
 extern VGM_HEADER VGMHead;
 extern UINT32 SampleRate;
-extern UINT32 VGMMaxLoopM;
-extern UINT32 FadeTime;
 extern bool EndPlay;
+
+extern UINT32 VGMMaxLoop;
+extern UINT32 FadeTime;
+
+enum output_format { L16, WAV, LWAV };
 
 INLINE int fputBE16(UINT16 Value, FILE* hFile)
 {
-    int RetVal;
-    int ResVal;
+	int RetVal;
+	int ResVal;
 
-    RetVal = fputc((Value & 0xFF00) >> 8, hFile);
-    RetVal = fputc((Value & 0x00FF) >> 0, hFile);
-    ResVal = (RetVal != EOF) ? 0x02 : 0x00;
-    return ResVal;
+	RetVal = fputc((Value & 0xFF00) >> 8, hFile);
+	RetVal = fputc((Value & 0x00FF) >> 0, hFile);
+	ResVal = (RetVal != EOF) ? 0x02 : 0x00;
+	return ResVal;
+}
+
+INLINE int fputLE16(UINT16 Value, FILE* hFile)
+{
+	int RetVal;
+	int ResVal;
+
+	RetVal = fputc((Value & 0x00FF) >> 0, hFile);
+	RetVal = fputc((Value & 0xFF00) >> 8, hFile);
+	ResVal = (RetVal != EOF) ? 0x02 : 0x00;
+	return ResVal;
+}
+
+INLINE int fputLE32(UINT32 Value, FILE* hFile)
+{
+	int RetVal;
+	int ResVal;
+
+	RetVal = fputc((Value & 0x000000FF) >> 0, hFile);
+	RetVal = fputc((Value & 0x0000FF00) >> 8, hFile);
+	RetVal = fputc((Value & 0x00FF0000) >> 16, hFile);
+	RetVal = fputc((Value & 0xFF000000) >> 24, hFile);
+	ResVal = (RetVal != EOF) ? 0x02 : 0x00;
+	return ResVal;
+}
+
+void usage(const char *name) {
+	fprintf(stderr, "usage: %s [options] vgm_file pcm_file\n"
+		"pcm_file can be - for standard output.\n", name);
+#ifdef VGM2PCM_HAS_GETOPT
+	fprintf(stderr, "\n"
+		"Default options:\n"
+		"--loop-count 2\n"
+		"--fade-ms 5000\n"
+		"--format L16\n"
+		"\n");
+#endif
 }
 
 int main(int argc, char *argv[]) {
-    UINT8 result;
-    WAVE_16BS *sampleBuffer;
-    UINT32 bufferedLength;
-    FILE *outputFile;
+	UINT8 result;
+	WAVE_16BS *sampleBuffer;
+	UINT32 bufferedLength;
+	FILE *outputFile;
+	enum output_format outputFormat = L16;
 
-    if (argc < 3) {
-        fputs("usage: vgm2pcm vgm_file pcm_file\n", stderr);
-        return 1;
-    }
+	long int wavRIFFLengthPos;
+	long int wavDataLengthPos;
+	int sampleBytesWritten = 0;
 
-    VGMPlay_Init();
-    VGMPlay_Init2();
+	// Initialize VGMPlay before parsing arguments, so we can set VGMMaxLoop and FadeTime
+	VGMPlay_Init();
+	VGMPlay_Init2();
 
-    if (!OpenVGMFile(argv[1])) {
-        fprintf(stderr, "vgm2pcm: error: failed to open vgm_file (%s)\n", argv[1]);
-        return 1;
-    }
+	int c;
 
-    outputFile = fopen(argv[2], "wb");
-    if (outputFile == NULL) {
-        fprintf(stderr, "vgm2pcm: error: failed to open pcm_file (%s)\n", argv[2]);
-        return 1;
-    }
+	// Parse command line arguments
+#ifdef VGM2PCM_HAS_GETOPT
+	static struct option long_options[] = {
+		{ "loop-count", required_argument, NULL, 'l' },
+		{ "fade-ms", required_argument, NULL, 'f' },
+		{ "format", required_argument, NULL, 't' },
+		{ "help", no_argument, NULL, '?' },
+		{ NULL, 0, NULL, 0 }
+	};
+	while ((c = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
+		switch (c) {
+		case 'l':
+			c = atoi(optarg);
+			if (c <= 0) {
+				fputs("Error: loop count must be at least 1.\n", stderr);
+				usage(argv[0]);
+				return 1;
+			}
+			VGMMaxLoop = c;
+			//fprintf(stderr, "Setting max loops to %u\n", VGMMaxLoop);
+			break;
+		case 'f':
+			FadeTime = atoi(optarg);
+			//fprintf(stderr, "Setting fade-out time in milliseconds to %u\n", FadeTime);
+			break;
+		case 't':
+			if (strcasecmp(optarg, "l16") == 0) {
+				outputFormat = L16;
+			} else if (strcasecmp(optarg, "wav") == 0) {
+				outputFormat = WAV;
+			} else if (strcasecmp(optarg, "lwav") == 0) {
+				outputFormat = LWAV;
+			} else {
+				fprintf(stderr, "Invalid output format: %s\n", optarg);
+				return 1;
+			}
+			break;
+		case -1:
+			break;
+		case '?':
+			usage(argv[0]);
+			return 0;
+		default:
+			usage(argv[0]);
+			return 1;
+		}
+	}
 
-    PlayVGM();
+	// Pretend for the rest of the program that those options don't exist
+	argv[optind - 1] = argv[0];
+	argc -= optind - 1;
+	argv += optind - 1;
+#endif
+	if (argc < 3) {
+		usage(argv[0]);
+		return 1;
+	}
 
-    sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
-    if (sampleBuffer == NULL) {
-        fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
-        return 1;
-    }
+	if (!OpenVGMFile(argv[1])) {
+		fprintf(stderr, "vgm2pcm: error: failed to open vgm_file (%s)\n", argv[1]);
+		return 1;
+	}
 
-    while (!EndPlay) {
-        UINT32 bufferSize = SampleRate;
-        bufferedLength = FillBuffer(sampleBuffer, bufferSize);
-        if (bufferedLength) {
-            UINT32 numberOfSamples;
-            UINT32 currentSample;
-            const UINT16* sampleData;
+	if (argv[2][0] == '-' && argv[2][1] == '\0') {
+#ifdef O_BINARY
+		setmode(fileno(stdout), O_BINARY);
+#endif
+		outputFile = stdout;
+	} else {
+		outputFile = fopen(argv[2], "wb");
+		if (outputFile == NULL) {
+			fprintf(stderr, "vgm2pcm: error: failed to open pcm_file (%s)\n", argv[2]);
+			return 1;
+		}
+	}
 
-            sampleData = (INT16*)sampleBuffer;
-            numberOfSamples = SAMPLESIZE * bufferedLength / 0x02;
-            for (currentSample = 0x00; currentSample < numberOfSamples; currentSample++) {
-                fputBE16(sampleData[currentSample], outputFile);
-            }
-        }
-    }
+	if (outputFormat == LWAV && VGMHead.lngLoopSamples == 0) {
+		outputFormat = WAV;
+	}
 
-    StopVGM();
+	if (outputFormat == WAV || outputFormat == LWAV) {
+		fwrite("RIFF", 1, 4, outputFile);
 
-    CloseVGMFile();
+		wavRIFFLengthPos = ftell(outputFile);
+		fputLE32(-1, outputFile);
 
-    VGMPlay_Deinit();
+		fwrite("WAVE", 1, 4, outputFile);
 
-    return 0;
+		fwrite("fmt ", 1, 4, outputFile);
+		fputLE32(16, outputFile);
+		fputLE16(1, outputFile);
+		fputLE16(2, outputFile);
+		fputLE32(SampleRate, outputFile);
+		fputLE32(SampleRate * 2 * 2, outputFile);
+		fputLE16(2 * 2, outputFile);
+		fputLE16(16, outputFile);
+
+		if (outputFormat == LWAV) {
+			fwrite("smpl", 1, 4, outputFile);
+			fputLE32(60, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(1, outputFile);
+			fputLE32(0, outputFile);
+
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(VGMHead.lngTotalSamples - VGMHead.lngLoopSamples, outputFile);
+			fputLE32(VGMHead.lngTotalSamples, outputFile);
+			fputLE32(0, outputFile);
+			fputLE32(0, outputFile);
+		}
+
+		fwrite("data", 1, 4, outputFile);
+
+		wavDataLengthPos = ftell(outputFile);
+		fputLE32(-1, outputFile);
+	}
+
+	PlayVGM();
+
+	sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
+	if (sampleBuffer == NULL) {
+		fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+		return 1;
+	}
+
+	while (!EndPlay) {
+		UINT32 bufferSize = SampleRate;
+		bufferedLength = FillBuffer(sampleBuffer, bufferSize);
+		if (bufferedLength) {
+			UINT32 numberOfSamples;
+			UINT32 currentSample;
+			const UINT16* sampleData;
+
+			sampleData = (INT16*)sampleBuffer;
+			numberOfSamples = SAMPLESIZE * bufferedLength / 0x02;
+			for (currentSample = 0x00; currentSample < numberOfSamples; currentSample++) {
+				if (outputFormat == L16) {
+					fputBE16(sampleData[currentSample], outputFile);
+				} else {
+					fputLE16(sampleData[currentSample], outputFile);
+					sampleBytesWritten += 2;
+				}
+			}
+		}
+	}
+
+	fflush(outputFile);
+	StopVGM();
+
+	CloseVGMFile();
+
+	VGMPlay_Deinit();
+
+	if (wavRIFFLengthPos >= 0) {
+		fseek(outputFile, wavRIFFLengthPos, SEEK_SET);
+		if (outputFormat == LWAV) {
+			fputLE32(sampleBytesWritten + 28 + 68 + 8, outputFile);
+		} else {
+			fputLE32(sampleBytesWritten + 28 + 8, outputFile);
+		}
+	}
+	if (wavDataLengthPos >= 0) {
+		fseek(outputFile, wavDataLengthPos, SEEK_SET);
+		fputLE32(sampleBytesWritten, outputFile);
+	}
+
+	return 0;
 }

--- a/VGMPlay/vgm2wav.c
+++ b/VGMPlay/vgm2wav.c
@@ -7,7 +7,7 @@
 
 #ifndef _MSC_VER
 // This turns command line options on (using getopt.h) unless you are using MSVC / Visual Studio, which doesn't have it.
-#define VGM2PCM_HAS_GETOPT
+#define VGM2WAV_HAS_GETOPT
 #include <getopt.h>
 #endif
 
@@ -27,18 +27,7 @@ extern bool EndPlay;
 extern UINT32 VGMMaxLoop;
 extern UINT32 FadeTime;
 
-enum output_format { L16, WAV, LWAV };
-
-INLINE int fputBE16(UINT16 Value, FILE* hFile)
-{
-	int RetVal;
-	int ResVal;
-
-	RetVal = fputc((Value & 0xFF00) >> 8, hFile);
-	RetVal = fputc((Value & 0x00FF) >> 0, hFile);
-	ResVal = (RetVal != EOF) ? 0x02 : 0x00;
-	return ResVal;
-}
+bool WriteSmplChunk;
 
 INLINE int fputLE16(UINT16 Value, FILE* hFile)
 {
@@ -65,24 +54,24 @@ INLINE int fputLE32(UINT32 Value, FILE* hFile)
 }
 
 void usage(const char *name) {
-	fprintf(stderr, "usage: %s [options] vgm_file pcm_file\n"
-		"pcm_file can be - for standard output.\n", name);
-#ifdef VGM2PCM_HAS_GETOPT
-	fprintf(stderr, "\n"
-		"Default options:\n"
-		"--loop-count 2\n"
-		"--fade-ms 5000\n"
-		"--format L16\n"
-		"\n");
+	fprintf(stderr, "usage: %s [options] vgm_file wav_file\n"
+		"wav_file can be - for standard output.\n", name);
+#ifdef VGM2WAV_HAS_GETOPT
+	fputs("\n"
+		"Options:\n"
+		"--loop-count {number}\n"
+		"--fade-ms {number}\n"
+		"--no-smpl-chunk\n"
+		"\n", stderr);
+#else
+	fputs("Options not supported in this build (compiled without getopt.)\n", stderr);
 #endif
 }
 
 int main(int argc, char *argv[]) {
-	UINT8 result;
 	WAVE_16BS *sampleBuffer;
 	UINT32 bufferedLength;
 	FILE *outputFile;
-	enum output_format outputFormat = L16;
 
 	long int wavRIFFLengthPos;
 	long int wavDataLengthPos;
@@ -92,14 +81,18 @@ int main(int argc, char *argv[]) {
 	VGMPlay_Init();
 	VGMPlay_Init2();
 
+	VGMMaxLoop = 2;
+	FadeTime = 5000;
+	WriteSmplChunk = true;
+
 	int c;
 
 	// Parse command line arguments
-#ifdef VGM2PCM_HAS_GETOPT
+#ifdef VGM2WAV_HAS_GETOPT
 	static struct option long_options[] = {
 		{ "loop-count", required_argument, NULL, 'l' },
 		{ "fade-ms", required_argument, NULL, 'f' },
-		{ "format", required_argument, NULL, 't' },
+		{ "no-smpl-chunk", no_argument, NULL, 'S' },
 		{ "help", no_argument, NULL, '?' },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -119,17 +112,8 @@ int main(int argc, char *argv[]) {
 			FadeTime = atoi(optarg);
 			//fprintf(stderr, "Setting fade-out time in milliseconds to %u\n", FadeTime);
 			break;
-		case 't':
-			if (strcasecmp(optarg, "l16") == 0) {
-				outputFormat = L16;
-			} else if (strcasecmp(optarg, "wav") == 0) {
-				outputFormat = WAV;
-			} else if (strcasecmp(optarg, "lwav") == 0) {
-				outputFormat = LWAV;
-			} else {
-				fprintf(stderr, "Invalid output format: %s\n", optarg);
-				return 1;
-			}
+		case 'S':
+			WriteSmplChunk = false;
 			break;
 		case -1:
 			break;
@@ -153,7 +137,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (!OpenVGMFile(argv[1])) {
-		fprintf(stderr, "vgm2pcm: error: failed to open vgm_file (%s)\n", argv[1]);
+		fprintf(stderr, "vgm2wav: error: failed to open vgm_file (%s)\n", argv[1]);
 		return 1;
 	}
 
@@ -165,64 +149,62 @@ int main(int argc, char *argv[]) {
 	} else {
 		outputFile = fopen(argv[2], "wb");
 		if (outputFile == NULL) {
-			fprintf(stderr, "vgm2pcm: error: failed to open pcm_file (%s)\n", argv[2]);
+			fprintf(stderr, "vgm2wav: error: failed to open wav_file (%s)\n", argv[2]);
 			return 1;
 		}
 	}
 
-	if (outputFormat == LWAV && VGMHead.lngLoopSamples == 0) {
-		outputFormat = WAV;
+	if (WriteSmplChunk && VGMHead.lngLoopSamples == 0) {
+		WriteSmplChunk = false;
 	}
 
-	if (outputFormat == WAV || outputFormat == LWAV) {
-		fwrite("RIFF", 1, 4, outputFile);
+	fwrite("RIFF", 1, 4, outputFile);
 
-		wavRIFFLengthPos = ftell(outputFile);
-		fputLE32(-1, outputFile);
+	wavRIFFLengthPos = ftell(outputFile);
+	fputLE32(-1, outputFile);
 
-		fwrite("WAVE", 1, 4, outputFile);
+	fwrite("WAVE", 1, 4, outputFile);
 
-		fwrite("fmt ", 1, 4, outputFile);
-		fputLE32(16, outputFile);
-		fputLE16(1, outputFile);
-		fputLE16(2, outputFile);
-		fputLE32(SampleRate, outputFile);
-		fputLE32(SampleRate * 2 * 2, outputFile);
-		fputLE16(2 * 2, outputFile);
-		fputLE16(16, outputFile);
+	fwrite("fmt ", 1, 4, outputFile);
+	fputLE32(16, outputFile);
+	fputLE16(1, outputFile);
+	fputLE16(2, outputFile);
+	fputLE32(SampleRate, outputFile);
+	fputLE32(SampleRate * 2 * 2, outputFile);
+	fputLE16(2 * 2, outputFile);
+	fputLE16(16, outputFile);
 
-		if (outputFormat == LWAV) {
-			fwrite("smpl", 1, 4, outputFile);
-			fputLE32(60, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(1, outputFile);
-			fputLE32(0, outputFile);
+	if (WriteSmplChunk) {
+		fwrite("smpl", 1, 4, outputFile);
+		fputLE32(60, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(1, outputFile);
+		fputLE32(0, outputFile);
 
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(VGMHead.lngTotalSamples - VGMHead.lngLoopSamples, outputFile);
-			fputLE32(VGMHead.lngTotalSamples, outputFile);
-			fputLE32(0, outputFile);
-			fputLE32(0, outputFile);
-		}
-
-		fwrite("data", 1, 4, outputFile);
-
-		wavDataLengthPos = ftell(outputFile);
-		fputLE32(-1, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(VGMHead.lngTotalSamples - VGMHead.lngLoopSamples, outputFile);
+		fputLE32(VGMHead.lngTotalSamples, outputFile);
+		fputLE32(0, outputFile);
+		fputLE32(0, outputFile);
 	}
+
+	fwrite("data", 1, 4, outputFile);
+
+	wavDataLengthPos = ftell(outputFile);
+	fputLE32(-1, outputFile);
 
 	PlayVGM();
 
 	sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
 	if (sampleBuffer == NULL) {
-		fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+		fprintf(stderr, "vgm2wav: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
 		return 1;
 	}
 
@@ -237,12 +219,8 @@ int main(int argc, char *argv[]) {
 			sampleData = (INT16*)sampleBuffer;
 			numberOfSamples = SAMPLESIZE * bufferedLength / 0x02;
 			for (currentSample = 0x00; currentSample < numberOfSamples; currentSample++) {
-				if (outputFormat == L16) {
-					fputBE16(sampleData[currentSample], outputFile);
-				} else {
-					fputLE16(sampleData[currentSample], outputFile);
-					sampleBytesWritten += 2;
-				}
+				fputLE16(sampleData[currentSample], outputFile);
+				sampleBytesWritten += 2;
 			}
 		}
 	}
@@ -256,7 +234,7 @@ int main(int argc, char *argv[]) {
 
 	if (wavRIFFLengthPos >= 0) {
 		fseek(outputFile, wavRIFFLengthPos, SEEK_SET);
-		if (outputFormat == LWAV) {
+		if (WriteSmplChunk) {
 			fputLE32(sampleBytesWritten + 28 + 68 + 8, outputFile);
 		} else {
 			fputLE32(sampleBytesWritten + 28 + 8, outputFile);

--- a/VGMPlay/vgm2wav.dsp
+++ b/VGMPlay/vgm2wav.dsp
@@ -1,4 +1,4 @@
-# Microsoft Developer Studio Project File - Name="VGMPlay" - Package Owner=<4>
+# Microsoft Developer Studio Project File - Name="vgm2pcm" - Package Owner=<4>
 # Microsoft Developer Studio Generated Build File, Format Version 6.00
 # ** NICHT BEARBEITEN **
 
@@ -51,7 +51,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
-# ADD LINK32 msvcrt.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /machine:I386 /nodefaultlib /libpath:"zlib"
+# ADD LINK32 msvcrt.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /machine:I386 /libpath:"zlib"
 # Begin Special Build Tool
 SOURCE="$(InputPath)"
 PostBuild_Cmds=..\vgm2txt\HiddenMsg.exe Release\VGMPlay.exe
@@ -80,7 +80,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 msvcrtd.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /debug /machine:I386 /nodefaultlib /libpath:"zlib"
+# ADD LINK32 msvcrtd.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /debug /machine:I386 /libpath:"zlib"
 # SUBTRACT LINK32 /profile /map
 
 !ENDIF 

--- a/VGMPlay/vgm2wav.dsp
+++ b/VGMPlay/vgm2wav.dsp
@@ -1,0 +1,1096 @@
+# Microsoft Developer Studio Project File - Name="VGMPlay" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** NICHT BEARBEITEN **
+
+# TARGTYPE "Win32 (x86) Console Application" 0x0103
+
+CFG=VGMPlay - Win32 Debug
+!MESSAGE Dies ist kein gültiges Makefile. Zum Erstellen dieses Projekts mit NMAKE
+!MESSAGE verwenden Sie den Befehl "Makefile exportieren" und führen Sie den Befehl
+!MESSAGE 
+!MESSAGE NMAKE /f "VGMPlay.mak".
+!MESSAGE 
+!MESSAGE Sie können beim Ausführen von NMAKE eine Konfiguration angeben
+!MESSAGE durch Definieren des Makros CFG in der Befehlszeile. Zum Beispiel:
+!MESSAGE 
+!MESSAGE NMAKE /f "VGMPlay.mak" CFG="VGMPlay - Win32 Debug"
+!MESSAGE 
+!MESSAGE Für die Konfiguration stehen zur Auswahl:
+!MESSAGE 
+!MESSAGE "VGMPlay - Win32 Release" (basierend auf  "Win32 (x86) Console Application")
+!MESSAGE "VGMPlay - Win32 Debug" (basierend auf  "Win32 (x86) Console Application")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "Release"
+# PROP BASE Intermediate_Dir "Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Release"
+# PROP Intermediate_Dir "Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Yu"stdafx.h" /FD /c
+# ADD CPP /nologo /MD /W3 /GX /Ox /Ot /Og /Oi /Ob2 /I "zlib" /D "NDEBUG" /D "WIN32_LEAN_AND_MEAN" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "ENABLE_ALL_CORES" /D "CONSOLE_MODE" /D "ADDITIONAL_FORMATS" /D "SET_CONSOLE_TITLE" /FD /c
+# SUBTRACT CPP /Oa /Ow /YX /Yc /Yu
+# ADD BASE RSC /l 0x407 /d "NDEBUG"
+# ADD RSC /l 0x407 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 msvcrt.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /machine:I386 /nodefaultlib /libpath:"zlib"
+# Begin Special Build Tool
+SOURCE="$(InputPath)"
+PostBuild_Cmds=..\vgm2txt\HiddenMsg.exe Release\VGMPlay.exe
+# End Special Build Tool
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "Debug"
+# PROP BASE Intermediate_Dir "Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Debug"
+# PROP Intermediate_Dir "Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /Yu"stdafx.h" /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "zlib" /D "_DEBUG" /D "WIN32_LEAN_AND_MEAN" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "ENABLE_ALL_CORES" /D "CONSOLE_MODE" /D "ADDITIONAL_FORMATS" /D "SET_CONSOLE_TITLE" /FR /FD /GZ /c
+# SUBTRACT CPP /YX /Yc /Yu
+# ADD BASE RSC /l 0x407 /d "_DEBUG"
+# ADD RSC /l 0x407 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 msvcrtd.lib kernel32.lib user32.lib advapi32.lib winmm.lib zdll.lib /nologo /subsystem:console /debug /machine:I386 /nodefaultlib /libpath:"zlib"
+# SUBTRACT LINK32 /profile /map
+
+!ENDIF 
+
+# Begin Target
+
+# Name "VGMPlay - Win32 Release"
+# Name "VGMPlay - Win32 Debug"
+# Begin Group "Quellcodedateien"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=.\pt_ioctl.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\Stream.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\VGMPlay.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\VGMPlay_AddFmts.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\vgm2wav.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# End Group
+# Begin Group "Header-Dateien"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl"
+# Begin Source File
+
+SOURCE=.\PortTalk_IOCTL.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\Stream.h
+# End Source File
+# Begin Source File
+
+SOURCE=".\XMasFiles\SWJ-SQRC01_1C.h"
+# End Source File
+# Begin Source File
+
+SOURCE=.\VGMFile.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\VGMPlay.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\VGMPlay_Intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\XMasFiles\XMasBonus.h
+# End Source File
+# End Group
+# Begin Group "Ressourcendateien"
+
+# PROP Default_Filter "ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"
+# End Group
+# Begin Group "SoundCore"
+
+# PROP Default_Filter "c;h;cpp"
+# Begin Group "FM OPL Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\2413intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2413intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2413tone.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\262intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\262intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\281btone.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\3526intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+# ADD CPP /W1
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\3526intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\3812intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+# ADD CPP /W1
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\3812intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\8950intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+# ADD CPP /W1
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\8950intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\adlibemu.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\adlibemu_opl2.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\adlibemu_opl3.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\emu2413.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\emu2413.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\emutypes.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\fmopl.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\fmopl.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\opl.c
+# PROP Exclude_From_Build 1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\opl.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\vrc7tone.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2413.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2413.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf262.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf262.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf278b.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf278b.h
+# End Source File
+# End Group
+# Begin Group "FM OPN Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\2203intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2203intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2608intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2608intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2610intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2610intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2612intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2612intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\fm.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\fm.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\fm2612.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2612.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2612.h
+# End Source File
+# End Group
+# Begin Group "FM OPx Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\2151intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\2151intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scsp.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scsp.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scspdsp.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scspdsp.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scsplfo.c
+# PROP Exclude_From_Build 1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2151.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2151.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf271.c
+# ADD CPP /W1
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymf271.h
+# End Source File
+# End Group
+# Begin Group "PCM Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\c140.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c140.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c352.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c352.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\es5503.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\es5503.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\es5506.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\es5506.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\iremga20.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\iremga20.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k053260.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k053260.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k054539.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k054539.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\multipcm.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\multipcm.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\okim6258.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\okim6258.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\okim6295.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\okim6295.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\pwm.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\pwm.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\qsound.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\qsound.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\rf5c68.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\rf5c68.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scd_pcm.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\scd_pcm.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\segapcm.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\segapcm.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\upd7759.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\upd7759.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\x1_010.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\x1_010.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymdeltat.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymdeltat.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymz280b.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+# ADD CPP /W1
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ymz280b.h
+# End Source File
+# End Group
+# Begin Group "OPL Mapper"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\ay8910_opl.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn76496_opl.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2413_opl.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2413hd.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /W1 /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ym2413hd.h
+# End Source File
+# End Group
+# Begin Group "PSG Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\ay8910.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ay8910.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ay_intf.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ay_intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c6280.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c6280.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c6280intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\c6280intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\emu2149.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\emu2149.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\gb.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\gb.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k051649.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\k051649.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\Ootake_PSG.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\Ootake_PSG.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\pokey.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\pokey.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\saa1099.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\saa1099.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn76489.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn76489.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn76496.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn76496.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn764intf.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\sn764intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\vsu.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\vsu.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ws_audio.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ws_audio.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\ws_initialIo.h
+# End Source File
+# End Group
+# Begin Group "NES Chips"
+
+# PROP Default_Filter "c;h"
+# Begin Source File
+
+SOURCE=.\chips\nes_apu.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\nes_apu.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\nes_defs.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\nes_intf.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\nes_intf.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_apu.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_apu.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_dmc.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_dmc.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_fds.c
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\np_nes_fds.h
+# End Source File
+# End Group
+# Begin Source File
+
+SOURCE=.\chips\ChipIncl.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\ChipMapper.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\ChipMapper.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\dac_control.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\dac_control.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\mamedef.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\panning.c
+
+!IF  "$(CFG)" == "VGMPlay - Win32 Release"
+
+# ADD CPP /Oa
+
+!ELSEIF  "$(CFG)" == "VGMPlay - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=.\chips\panning.h
+# End Source File
+# End Group
+# Begin Source File
+
+SOURCE=.\ReadMe.txt
+# End Source File
+# End Target
+# End Project


### PR DESCRIPTION
vgm2wav reads in a VGM/VGZ file and exports a PCM WAV file, with or without a "smpl" chunk to denote the start and end of the looping section of the VGM. It also has command-line options to change the amount of loops played and amount of fade-out time at the end, and allows the use of standard output instead of a file (although using standard output with WAV format will give a non-conforming file, using -1 for the length of the RIFF and of the data chunk, since stdout is not seekable.)

Notes:
* I added a GPL2+ licensing header to vgm2wav.c. I didn't know exactly whose names to put in as secondary authors, but I figured Francis Gagné (vgm2pcm author) should be one of them.
* I also put in a .dsp file - not tested with VC++ 6, but it loads and converts in VS 2013, and I like using Visual Studio to edit my code. vgm2wav.c will detect Visual Studio and compile without getopt support (no command line options) - of course this isn't recommended except for testing purposes.