### PR TITLE
Replace malloc.h by stdlib.h

### DIFF
--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -76,10 +76,7 @@ ifdef WINDOWS
 LDFLAGS += -lkernel32 -lwinmm
 else
 
-ifdef MACOSX
-# malloc.h fix (required as long as I haven't fixed the include lines)
-CFLAGS += -I/usr/include/malloc
-else
+ifndef MACOSX
 # for Linux, add librt (clock stuff) and libpthread (threads)
 LDFLAGS += -lrt -lpthread -pthread
 endif

--- a/VGMPlay/Stream.c
+++ b/VGMPlay/Stream.c
@@ -5,7 +5,7 @@
 
 #include <stdio.h>
 #include "stdbool.h"
-#include <malloc.h>
+#include <stdlib.h>
 
 #ifdef WIN32
 #include <windows.h>

--- a/VGMPlay/chips/2203intf.c
+++ b/VGMPlay/chips/2203intf.c
@@ -1,6 +1,6 @@
 #include <math.h>
 #include <memory.h>	// for memset
-#include <malloc.h>	// for free
+#include <stdlib.h>	// for free
 #include <stddef.h>	// for NULL
 #include "mamedef.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/2608intf.c
+++ b/VGMPlay/chips/2608intf.c
@@ -12,7 +12,7 @@
 ***************************************************************************/
 
 #include <memory.h>	// for memset
-#include <malloc.h>	// for free
+#include <stdlib.h>	// for free
 #include <stddef.h>	// for NULL
 #include "mamedef.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/2610intf.c
+++ b/VGMPlay/chips/2610intf.c
@@ -12,7 +12,7 @@
 ***************************************************************************/
 
 #include <memory.h>	// for memset
-#include <malloc.h>	// for free
+#include <stdlib.h>	// for free
 #include <stddef.h>	// for NULL
 #include "mamedef.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/2612intf.c
+++ b/VGMPlay/chips/2612intf.c
@@ -11,7 +11,7 @@
 
 ***************************************************************************/
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <stddef.h>	// for NULL
 #include "mamedef.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/Ootake_PSG.c
+++ b/VGMPlay/chips/Ootake_PSG.c
@@ -49,7 +49,7 @@ Copyright(C)2006-2012 Kitao Nakamura.
     GNU General Public License for more details.
 ******************************************************************************/
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <math.h>
 #include "mamedef.h"

--- a/VGMPlay/chips/ay8910.c
+++ b/VGMPlay/chips/ay8910.c
@@ -116,7 +116,7 @@ has twice the steps, happening twice as fast.
 //#include "streams.h"
 //#include "cpuintrf.h"
 //#include "cpuexec.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stdio.h>
 #include "ay8910.h"

--- a/VGMPlay/chips/ay_intf.c
+++ b/VGMPlay/chips/ay_intf.c
@@ -5,7 +5,7 @@
 ****************************************************************/
 
 #include <memory.h>	// for memset
-#include <malloc.h>	// for free
+#include <stdlib.h>	// for free
 #include <stddef.h>	// for NULL
 #include "mamedef.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/c140.c
+++ b/VGMPlay/chips/c140.c
@@ -44,7 +44,7 @@ Unmapped registers:
 
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include "mamedef.h"
 #include "c140.h"

--- a/VGMPlay/chips/c352.c
+++ b/VGMPlay/chips/c352.c
@@ -16,7 +16,7 @@
 //#include "emu.h"
 //#include "streams.h"
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/es5503.c
+++ b/VGMPlay/chips/es5503.c
@@ -38,7 +38,7 @@
 
 //#include "emu.h"
 //#include "streams.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include "mamedef.h"
 #include "es5503.h"

--- a/VGMPlay/chips/es5506.c
+++ b/VGMPlay/chips/es5506.c
@@ -81,7 +81,7 @@ Ensoniq OTIS - ES5505                                            Ensoniq OTTO - 
 ***********************************************************************************************/
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>	// for memset
 #include "mamedef.h"
 #include "es5506.h"

--- a/VGMPlay/chips/fm.c
+++ b/VGMPlay/chips/fm.c
@@ -116,7 +116,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include "mamedef.h"
 //#ifndef __RAINE__

--- a/VGMPlay/chips/fm2612.c
+++ b/VGMPlay/chips/fm2612.c
@@ -129,7 +129,7 @@
 /************************************************************************/
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <math.h>
 #include "mamedef.h"

--- a/VGMPlay/chips/fmopl.c
+++ b/VGMPlay/chips/fmopl.c
@@ -72,7 +72,7 @@ Revision History:
 #ifdef _DEBUG
 #include <stdio.h>
 #endif
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 //#include "sndintrf.h"
 #include "fmopl.h"

--- a/VGMPlay/chips/iremga20.c
+++ b/VGMPlay/chips/iremga20.c
@@ -27,7 +27,7 @@ Revisions:
 *********************************************************/
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/k051649.c
+++ b/VGMPlay/chips/k051649.c
@@ -23,7 +23,7 @@
 ***************************************************************************/
 
 #include "mamedef.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 //#include "emu.h"
 //#include "streams.h"

--- a/VGMPlay/chips/k053260.c
+++ b/VGMPlay/chips/k053260.c
@@ -9,7 +9,7 @@
 #ifdef _DEBUG
 #include <stdio.h>
 #endif
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include "k053260.h"
 

--- a/VGMPlay/chips/k054539.c
+++ b/VGMPlay/chips/k054539.c
@@ -8,7 +8,7 @@
 *********************************************************/
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <math.h>
 #include "mamedef.h"

--- a/VGMPlay/chips/multipcm.c
+++ b/VGMPlay/chips/multipcm.c
@@ -36,7 +36,7 @@
 #include "mamedef.h"
 #include <math.h>
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "multipcm.h"
 
 #define NULL	((void *)0)

--- a/VGMPlay/chips/nes_apu.c
+++ b/VGMPlay/chips/nes_apu.c
@@ -45,7 +45,7 @@
  *****************************************************************************/
 
 #include "mamedef.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stddef.h>	// for NULL
 //#include "emu.h"

--- a/VGMPlay/chips/nes_intf.c
+++ b/VGMPlay/chips/nes_intf.c
@@ -6,7 +6,7 @@
 
 #include "mamedef.h"
 #include <memory.h>	// for memset
-#include <malloc.h>	// for free
+#include <stdlib.h>	// for free
 #include <stddef.h>	// for NULL
 #include "../stdbool.h"
 //#include "sndintrf.h"

--- a/VGMPlay/chips/np_nes_apu.c
+++ b/VGMPlay/chips/np_nes_apu.c
@@ -7,7 +7,7 @@
 // (Note: Encoding is UTF-8)
 
 //#include <assert.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>	// for memset()
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/np_nes_dmc.c
+++ b/VGMPlay/chips/np_nes_dmc.c
@@ -4,7 +4,7 @@
 // (Note: Encoding is UTF-8)
 
 #include <stdlib.h>	// for rand()
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>	// for memset()
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/np_nes_fds.c
+++ b/VGMPlay/chips/np_nes_fds.c
@@ -2,7 +2,7 @@
 // by Valley Bell on 26 September 2013
 
 #include <stdlib.h>	// for rand()
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>	// for memset()
 #include <stddef.h>	// for NULL
 #include <math.h>	// for exp()

--- a/VGMPlay/chips/okim6295.c
+++ b/VGMPlay/chips/okim6295.c
@@ -25,7 +25,7 @@
 //#include "emu.h"
 //#include "streams.h"
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <math.h>
 #include "okim6295.h"

--- a/VGMPlay/chips/qsound.c
+++ b/VGMPlay/chips/qsound.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #endif
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include "qsound.h"
 

--- a/VGMPlay/chips/rf5c68.c
+++ b/VGMPlay/chips/rf5c68.c
@@ -4,7 +4,7 @@
 
 #include "mamedef.h"
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 //#include "sndintrf.h"
 //#include "streams.h"
 #include "rf5c68.h"

--- a/VGMPlay/chips/scd_pcm.c
+++ b/VGMPlay/chips/scd_pcm.c
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include "mamedef.h"
 #include "scd_pcm.h"

--- a/VGMPlay/chips/scsp.c
+++ b/VGMPlay/chips/scsp.c
@@ -31,7 +31,7 @@
 #include "mamedef.h"
 #include <math.h>	// for pow() in scsplfo.c
 #include <stdlib.h>
-//#include <malloc.h>
+//#include <stdlib.h>
 #include <memory.h>	// for memset
 #include "scsp.h"
 #include "scspdsp.h"

--- a/VGMPlay/chips/segapcm.c
+++ b/VGMPlay/chips/segapcm.c
@@ -4,7 +4,7 @@
 
 #include "mamedef.h"
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 //#include "sndintrf.h"
 //#include "streams.h"

--- a/VGMPlay/chips/sn76496.c
+++ b/VGMPlay/chips/sn76496.c
@@ -125,7 +125,7 @@
 //#include "emu.h"
 //#include "streams.h"
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "sn76496.h"
 
 #define NULL	((void *)0)

--- a/VGMPlay/chips/upd7759.c
+++ b/VGMPlay/chips/upd7759.c
@@ -103,7 +103,7 @@
 #include <stdio.h>
 #endif
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "mamedef.h"
 #include "upd7759.h"
 

--- a/VGMPlay/chips/ws_audio.c
+++ b/VGMPlay/chips/ws_audio.c
@@ -1,5 +1,5 @@
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/x1_010.c
+++ b/VGMPlay/chips/x1_010.c
@@ -49,7 +49,7 @@ Registers:
 ***************************************************************************/
 
 //#include "emu.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stddef.h>	// for NULL
 #include "mamedef.h"

--- a/VGMPlay/chips/ym2151.c
+++ b/VGMPlay/chips/ym2151.c
@@ -8,7 +8,7 @@
 #include <math.h>
 
 #include "mamedef.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 //#include "sndintrf.h"
 //#include "streams.h"

--- a/VGMPlay/chips/ym2413.c
+++ b/VGMPlay/chips/ym2413.c
@@ -40,7 +40,7 @@ to do:
 #include <stdio.h>
 #include <math.h>
 #include "mamedef.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 //#include "sndintrf.h"
 #include "ym2413.h"

--- a/VGMPlay/chips/ymf262.c
+++ b/VGMPlay/chips/ymf262.c
@@ -55,7 +55,7 @@ differences between OPL2 and OPL3 shown in datasheets:
 
 #include <math.h>
 #include "mamedef.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 //#include "sndintrf.h"
 #include "ymf262.h"

--- a/VGMPlay/chips/ymf271.c
+++ b/VGMPlay/chips/ymf271.c
@@ -33,7 +33,7 @@
 #ifdef _DEBUG
 #include <stdio.h>
 #endif
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include "ymf271.h"
 

--- a/VGMPlay/chips/ymf278b.c
+++ b/VGMPlay/chips/ymf278b.c
@@ -63,7 +63,7 @@
 //#include "sndintrf.h"
 //#include "streams.h"
 //#include "cpuintrf.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <memory.h>
 #include <stdio.h>
 #include <string.h>

--- a/VGMPlay/chips/ymz280b.c
+++ b/VGMPlay/chips/ymz280b.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #endif
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "ymz280b.h"
 
 #define NULL	((void *)0)


### PR DESCRIPTION
Fixes #21 

Hello @ValleyBell ,

Sorry for the long delay.

I made this change using a regular expression so I guess some unneeded includes probably remain. It works for me on OSX El Captain 10.11.4 but I still had to add a few changes in the Makefile. Maybe you can check if something makes sense to you.

```diff
diff --git a/VGMPlay/Makefile b/VGMPlay/Makefile
index 10e97f6..98ccc5e 100644
--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -13,10 +13,10 @@
 #WINDOWS = 1
 
 # Uncomment if you build on Mac OSX
-#MACOSX = 1
+MACOSX = 1
 
 # disable Hardware OPL Support
-#DISABLE_HWOPL_SUPPORT = 1
+DISABLE_HWOPL_SUPPORT = 1
 
 # Uncomment if you want to use libao instead of OSS for sound streaming under Linux
 USE_LIBAO = 1
@@ -78,7 +78,7 @@ else
 
 ifdef MACOSX
 # malloc.h fix (required as long as I haven't fixed the include lines)
-CFLAGS += -I/usr/include/malloc
+CFLAGS += -I/usr/local/Cellar/libao/1.2.0/include
 else
 # for Linux, add librt (clock stuff) and libpthread (threads)
 LDFLAGS += -lrt -lpthread -pthread
```

Is HWOPL support available on OSX?

My `ao/ao.h` is located there: `/usr/local/Cellar/libao/1.2.0/include`. The compilation fails if I don't specify it.

`-I/usr/include/malloc` seems to be not needed anymore.