### PR TITLE
Add stereo AY chip support to VGMPlay

### DIFF
--- a/VGMPlay/VGMPlay.c
+++ b/VGMPlay/VGMPlay.c
@@ -276,6 +276,8 @@ static void ChangeChipSampleRate(void* DataPtr, UINT32 NewSmplRate);
 INLINE INT16 Limit2Short(INT32 Value);
 static void null_update(UINT8 ChipID, stream_sample_t **outputs, int samples);
 static void dual_opl2_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples);
+static void dual_ay8910_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples);
+static void dual_ym2203ay_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples);
 static void ResampleChipStream(CA_LIST* CLst, WAVE_32BS* RetSample, UINT32 Length);
 static INT32 RecalcFadeVolume(void);
 //UINT32 FillBuffer(WAVE_16BS* Buffer, UINT32 BufferSize)
@@ -2797,7 +2799,7 @@ static void Chips_GeneralActions(UINT8 Mode)
 													VGMHead.bytAYFlagYM2203,
 													(int*)&CAA->Paired->SmpRate);
 				CAA->StreamUpdate = &ym2203_stream_update;
-				CAA->Paired->StreamUpdate = &ym2203_stream_update_ay;
+				CAA->Paired->StreamUpdate = (VGMHead.lngHzYM2203 & 0x80000000) ? dual_ym2203ay_stereo :&ym2203_stream_update_ay;
 				ym2203_set_srchg_cb(CurChip, &ChangeChipSampleRate, CAA, CAA->Paired);
 				
 				CAA->Volume = GetChipVolume(&VGMHead, CAA->ChipType, CurChip, ChipCnt);
@@ -3087,7 +3089,7 @@ static void Chips_GeneralActions(UINT8 Mode)
 				{
 					CAA->SmpRate = device_start_ayxx(CurChip, ChipClk,
 													VGMHead.bytAYType, VGMHead.bytAYFlag);
-					CAA->StreamUpdate = &ayxx_stream_update;
+					CAA->StreamUpdate = (VGMHead.lngHzAY8910 & 0x80000000) ? dual_ay8910_stereo :&ayxx_stream_update;
 					
 					CAA->Volume = GetChipVolume(&VGMHead, CAA->ChipType, CurChip, ChipCnt);
 					AbsVol += CAA->Volume * 2;
@@ -5848,6 +5850,32 @@ static void null_update(UINT8 ChipID, stream_sample_t **outputs, int samples)
 static void dual_opl2_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples)
 {
 	ym3812_stream_update(ChipID, outputs, samples);
+	
+	// Dual-OPL with Stereo
+	if (ChipID & 0x01)
+		memset(outputs[0x00], 0x00, sizeof(stream_sample_t) * samples);	// Mute Left Chanel
+	else
+		memset(outputs[0x01], 0x00, sizeof(stream_sample_t) * samples);	// Mute Right Chanel
+	
+	return;
+}
+
+static void dual_ay8910_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples)
+{
+	ayxx_stream_update(ChipID, outputs, samples);
+	
+	// Dual-OPL with Stereo
+	if (ChipID & 0x01)
+		memset(outputs[0x00], 0x00, sizeof(stream_sample_t) * samples);	// Mute Left Chanel
+	else
+		memset(outputs[0x01], 0x00, sizeof(stream_sample_t) * samples);	// Mute Right Chanel
+	
+	return;
+}
+
+static void dual_ym2203ay_stereo(UINT8 ChipID, stream_sample_t **outputs, int samples)
+{
+	ym2203_stream_update_ay(ChipID, outputs, samples);
 	
 	// Dual-OPL with Stereo
 	if (ChipID & 0x01)

--- a/VGMPlay/VGMPlay.c
+++ b/VGMPlay/VGMPlay.c
@@ -5864,7 +5864,7 @@ static void dual_ay8910_stereo(UINT8 ChipID, stream_sample_t **outputs, int samp
 {
 	ayxx_stream_update(ChipID, outputs, samples);
 	
-	// Dual-OPL with Stereo
+	// Dual AY8910 with Stereo
 	if (ChipID & 0x01)
 		memset(outputs[0x00], 0x00, sizeof(stream_sample_t) * samples);	// Mute Left Chanel
 	else
@@ -5877,7 +5877,7 @@ static void dual_ym2203ay_stereo(UINT8 ChipID, stream_sample_t **outputs, int sa
 {
 	ym2203_stream_update_ay(ChipID, outputs, samples);
 	
-	// Dual-OPL with Stereo
+	// Dual YM2203 (AY part) with Stereo
 	if (ChipID & 0x01)
 		memset(outputs[0x00], 0x00, sizeof(stream_sample_t) * samples);	// Mute Left Chanel
 	else

--- a/VGMPlay/chips/2203intf.c
+++ b/VGMPlay/chips/2203intf.c
@@ -422,6 +422,25 @@ void ym2203_set_mute_mask(UINT8 ChipID, UINT32 MuteMaskFM, UINT32 MuteMaskAY)
 	}
 }
 
+void ym2203_set_stereo_mask_ay(UINT8 ChipID, UINT32 StereoMaskAY)
+{
+	ym2203_state *info = &YM2203Data[ChipID];
+	if (info->psg != NULL)
+	{
+		switch(AY_EMU_CORE)
+		{
+#ifdef ENABLE_ALL_CORES
+		case EC_MAME:
+			ay8910_set_stereo_mask_ym(info->psg, StereoMaskAY);
+			break;
+#endif
+		case EC_EMU2149:
+			PSG_setStereoMask((PSG*)info->psg, StereoMaskAY);
+			break;
+		}
+	}
+}
+
 void ym2203_set_srchg_cb(UINT8 ChipID, SRATE_CALLBACK CallbackFunc, void* DataPtr, void* AYDataPtr)
 {
 	ym2203_state *info = &YM2203Data[ChipID];

--- a/VGMPlay/chips/2203intf.h
+++ b/VGMPlay/chips/2203intf.h
@@ -41,4 +41,5 @@ void ym2203_write_port_w(UINT8 ChipID, offs_t offset, UINT8 data);
 
 void ym2203_set_ay_emu_core(UINT8 Emulator);
 void ym2203_set_mute_mask(UINT8 ChipID, UINT32 MuteMaskFM, UINT32 MuteMaskAY);
+void ym2203_set_stereo_mask_ay(UINT8 ChipID, UINT32 StereoMaskAY);
 void ym2203_set_srchg_cb(UINT8 ChipID, SRATE_CALLBACK CallbackFunc, void* DataPtr, void* AYDataPtr);

--- a/VGMPlay/chips/ay8910.c
+++ b/VGMPlay/chips/ay8910.c
@@ -1335,6 +1335,18 @@ void ay8910_set_mute_mask_ym(void *chip, UINT32 MuteMask)
 	return;
 }
 
+void ay8910_set_stereo_mask_ym(void *chip, UINT32 StereoMask)
+{
+	ay8910_context *psg = (ay8910_context *)chip;
+	UINT8 CurChn;
+	
+	for (CurChn = 0; CurChn < NUM_CHANNELS; CurChn ++) {
+		psg->StereoMask[CurChn] = StereoMask &3;
+		StereoMask >>= 2;
+	}	
+	return;
+}
+
 /*void ay8910_set_mute_mask(UINT8 ChipID, UINT32 MuteMask)
 {
 	ay8910_context *psg = &AY8910Data[ChipID];

--- a/VGMPlay/chips/ay8910.h
+++ b/VGMPlay/chips/ay8910.h
@@ -121,6 +121,7 @@ void device_stop_ay8910(UINT8 ChipID);
 void device_reset_ay8910(UINT8 ChipID);*/
 
 void ay8910_set_mute_mask_ym(void *chip, UINT32 MuteMask);
+void ay8910_set_stereo_mask_ym(void *chip, UINT32 StereoMask);
 //void ay8910_set_mute_mask(UINT8 ChipID, UINT32 MuteMask);
 void ay8910_set_srchg_cb_ym(void *chip, SRATE_CALLBACK CallbackFunc, void* DataPtr);
 

--- a/VGMPlay/chips/ay_intf.c
+++ b/VGMPlay/chips/ay_intf.c
@@ -168,3 +168,21 @@ void ayxx_set_mute_mask(UINT8 ChipID, UINT32 MuteMask)
 	
 	return;
 }
+
+void ayxx_set_stereo_mask(UINT8 ChipID, UINT32 StereoMask)
+{
+	ayxx_state *info = &AYxxData[ChipID];
+	switch(EMU_CORE)
+	{
+#ifdef ENABLE_ALL_CORES
+	case EC_MAME:
+		ay8910_set_stereo_mask_ym(info->chip, StereoMask);
+		break;
+#endif
+	case EC_EMU2149:
+		PSG_setStereoMask((PSG*)info->chip, StereoMask);
+		break;
+	}
+	
+	return;
+}

--- a/VGMPlay/chips/ay_intf.h
+++ b/VGMPlay/chips/ay_intf.h
@@ -10,3 +10,4 @@ void ayxx_w(UINT8 ChipID, offs_t offset, UINT8 data);
 
 void ayxx_set_emu_core(UINT8 Emulator);
 void ayxx_set_mute_mask(UINT8 ChipID, UINT32 MuteMask);
+void ayxx_set_stereo_mask(UINT8 ChipID, UINT32 StereoMask);

--- a/VGMPlay/chips/emu2149.c
+++ b/VGMPlay/chips/emu2149.c
@@ -145,6 +145,18 @@ PSG_setMask (PSG *psg, e_uint32 mask)
   return ret;
 }
 
+EMU2149_API void
+PSG_setStereoMask (PSG *psg, e_uint32 mask)
+{
+  e_uint32 ret = 0;
+  if(psg)
+  {
+    psg->stereo_mask[0] = (mask >>0) &3;
+    psg->stereo_mask[1] = (mask >>2) &3;
+    psg->stereo_mask[2] = (mask >>4) &3;
+  }  
+}
+
 EMU2149_API e_uint32
 PSG_toggleMask (PSG *psg, e_uint32 mask)
 {

--- a/VGMPlay/chips/emu2149.h
+++ b/VGMPlay/chips/emu2149.h
@@ -94,6 +94,7 @@ extern "C"
   EMU2149_API void PSG_setVolumeMode (PSG * psg, int type);
   EMU2149_API e_uint32 PSG_setMask (PSG *, e_uint32 mask);
   EMU2149_API e_uint32 PSG_toggleMask (PSG *, e_uint32 mask);
+  EMU2149_API void PSG_setStereoMask (PSG *psg, e_uint32 mask);
     
 /*#ifdef __cplusplus
 }

--- a/VGMPlay/vgmspec171.txt
+++ b/VGMPlay/vgmspec171.txt
@@ -59,7 +59,8 @@ The format starts with a 256 byte header:
         to indicate that this is a T6W28. (PSG variant used in NeoGeo Pocket)
 0x10: YM2413 clock (32 bits)
         Input clock rate in Hz for the YM2413 chip. A typical value is 3579545.
-        It should be 0 if there is no YM2413 chip used.
+        It should be 0 if there is no YM2413 chip used. Set bit 31 (0x80000000)
+	to denote that the chip is a VRC7 rather than an original YM2413.
 0x14: GD3 offset (32 bits)
         Relative offset to GD3 tag. 0 if no GD3 tag.
         GD3 tags are descriptive tags similar in use to ID3 tags in MP3 files.
@@ -120,6 +121,8 @@ The format starts with a 256 byte header:
         It should be 0 if there us no YM2612 chip used.
         For version 1.01 and earlier files, the YM2413 clock rate should be
         used for the clock rate of the YM2612.
+	Set bit 31 (0x80000000) co denote that the chip is an YM3438 rather
+	than an original YM2413.
 0x30: YM2151 clock (32 bits)
         Input clock rate in Hz for the YM2151 chip. A typical value is 3579545.
         It should be 0 if there us no YM2151 chip used.
@@ -128,7 +131,7 @@ The format starts with a 256 byte header:
 [VGM 1.50 additions:]
 0x34: VGM data offset (32 bits)
         Relative offset to VGM data stream.
-        If the VGM data starts at absolute offset 0x40, this will contain 
+        If the VGM data starts at absolute offset 0x40, this will contain
         value 0x0000000C. For versions prior to 1.50, it should be 0 and the
         VGM data must start at offset 0x40.
 [VGM 1.51 additions:]
@@ -201,7 +204,8 @@ The format starts with a 256 byte header:
         bit 2   Discrete Output
         bit 3   RAW Output
         bit 4   YM2149 Pin 26 (additional /2 clock divider)
-        bit 5-7 reserved (must be zero)
+        bit 5-6 reserved (must be zero)
+	bit 7   Use ZX-Spectrum-like pan configuration (Left-Center-Right).
         If the AY8910 is not used then this may be omitted (left at zero).
 0x7A: YM2203/AY8910 Flags (8 bits)
         Misc flags for the AY8910. This one is specific for the AY8910 that's
@@ -252,7 +256,9 @@ The format starts with a 256 byte header:
         8053975. It should be 0 if there is no MultiPCM chip used.
 0x8C: uPD7759 clock (32 bits)
         Input clock rate in Hz for the uPD7759 chip. A typical value is 640000.
-        It should be 0 if there is no uPD7759 chip used.
+        It should be 0 if there is no uPD7759 chip used. Set bit 31 (0x80000000)
+	to denote that the chip is in a Slave, clear bit 31 to denote that the
+	chip is in a Master configuration.
 0x90: OKIM6258 clock (32 bits)
         Input clock rate in Hz for the OKIM6258 chip. A typical value is
         4000000. It should be 0 if there is no OKIM6258 chip used.
@@ -282,9 +288,12 @@ The format starts with a 256 byte header:
 0x98: OKIM6295 clock (32 bits)
         Input clock rate in Hz for the OKIM6295 chip. A typical value is
         8000000. It should be 0 if there is no OKIM6295 chip used.
+	Set bit 31 (0x80000000) to denote the status of pin 7.
 0x9C: K051649 clock (32 bits)
         Input clock rate in Hz for the K051649 chip. A typical value is
         1500000. It should be 0 if there is no K051649 chip used.
+	Set bit 31 (0x80000000)	to denote that the chip is an SCC+ rather
+	than an original SCC.
 0xA0: K054539 clock (32 bits)
         Input clock rate in Hz for the K054539 chip. A typical value is
         18432000. It should be 0 if there is no K054539 chip used.
@@ -295,7 +304,7 @@ The format starts with a 256 byte header:
         Input clock rate in Hz for the C140 chip. A typical value is 8000000.
         It should be 0 if there is no C140 chip used.
 0xAC: K053260 clock (32 bits)
-        Input clock rate in Hz for the K053260 chip. A typical value is 
+        Input clock rate in Hz for the K053260 chip. A typical value is
         3579545. It should be 0 if there is no K053260 chip used.
 0xB0: Pokey clock (32 bits)
         Input clock rate in Hz for the Pokey chip. A typical value is 1789772.
@@ -362,6 +371,12 @@ Starting at the location specified by the VGM data offset (or, offset 0x40 for
 file versions below 1.50) is found a sequence of commands containing data
 written to the chips or timing information. A command is one of:
 
+  0x3E dd    : Set AY8910 stereo mask.
+               Bit 0-1: Channel A mask (00=off, 01=left, 10=right, 11=center)
+               Bit 2-3: Channel B mask (00=off, 01=left, 10=right, 11=center)
+               Bit 4-5: Channel C mask (00=off, 01=left, 10=right, 11=center)
+               Bit 6: Chip type, 0=AY8910, 1=YM2203 AY8910 part.
+               Bit 7: Chip number, 0 or 1.
   0x4F dd    : Game Gear PSG stereo, write dd to port 0x06
   0x50 dd    : PSG (SN76489/SN76496) write value dd
   0x51 aa dd : YM2413, write value dd to register aa
@@ -394,7 +409,7 @@ written to the chips or timing information. A command is one of:
   0x67 ...   : data block: see below
   0x68 ...   : PCM RAM write: see below
   0x7n       : wait n+1 samples, n can range from 0 to 15.
-  0x8n       : YM2612 port 0 address 2A write from the data bank, then wait 
+  0x8n       : YM2612 port 0 address 2A write from the data bank, then wait
                n samples; n can range from 0 to 15. Note that the wait is n,
                NOT n+1. (Note: Written to first chip instance only.)
   0x90-0x95  : DAC Stream Control Write: see below
@@ -478,7 +493,7 @@ Data blocks of recorded streams, if present, should be at the very start of the
 VGM data. Multiple data blocks expand the data bank. (The start offset and
 length of the block in the data bank should be saved for command 0x95.)
 Because data blocks can happen anywhere in the stream, players must be able to
-parse data blocks anywhere in the stream. 
+parse data blocks anywhere in the stream.
 
 The data block type specifies what type of data it contains. Currently defined
 types are:
@@ -715,6 +730,11 @@ between the 1st and 2nd chip. (0x00-7F = Chip 1, 0x80-0xFF = chip 2)
 Note: The SegaPCM chip has the 2nd-chip-bit in the high byte of the address
 parameter. This is the second parameter byte.
 
+Note: For the YM3812 only, setting bit 31 (0x80000000) in the chip's clock
+value hard-pans the first chip on the left and the second chip on the right.
+This replicates the pan configuration of the Sound Blaster Pro 1 and Pro
+Audio Spectrum sound cards on the IBM PC.
+
 
 Extra Header
 ------------
@@ -776,7 +796,7 @@ Rate value added by Maxim; 1.00 files are fully compatible
 [1.10]
 PSG white noise feedback and shift register width parameters added by Maxim,
 with note on how to handle earlier version files.
-Additional wait command added by Maxim with thanks to Steve Snake for the 
+Additional wait command added by Maxim with thanks to Steve Snake for the
 suggestion.
 1.01 files are fully compatible but 1.01 players might have problems
 with 1.10 files, hence the 0.1 version change.


### PR DESCRIPTION
Enabled by setting bit 31 of the AY8910 and YM2203 chip clock(s).

Needed for the correct reproduction of Apple Mockingboard A and a few arcade games.