### PR TITLE
Add OpenBSD support (libAO only).

### DIFF
--- a/VGMPlay/Stream.c
+++ b/VGMPlay/Stream.c
@@ -16,7 +16,7 @@
 #include <fcntl.h>
 #ifdef __NetBSD__
 #include <sys/audioio.h>
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__OpenBSD__)
 // nothing
 #else
 #include <linux/soundcard.h>

--- a/VGMPlay/VGMPlay.c
+++ b/VGMPlay/VGMPlay.c
@@ -5666,7 +5666,7 @@ static void InterpretVGM(UINT32 SampleCount)
 #ifdef CONSOLE_MODE
 				if (! CmdList[Command])
 				{
-					fprintf(stderr, "Unknown command: %02hX\n", Command);
+					fprintf(stderr, "Unknown command: %02hhX\n", Command);
 					CmdList[Command] = true;
 				}
 #endif

--- a/VGMPlay/VGMPlayUI.c
+++ b/VGMPlay/VGMPlayUI.c
@@ -2290,11 +2290,11 @@ static void PlayVGM_UI(void)
 			if (Show95Cmds && Last95Max != 0xFFFF)
 			{
 				if (Show95Cmds == 0x01)
-					printf("  %02hX / %02hX", 1 + Last95Drum, Last95Max);
+					printf("  %02X / %02hX", 1 + Last95Drum, Last95Max);
 				else if (Show95Cmds == 0x02)
-					printf("  %02hX / %02hX at %5u Hz", 1 + Last95Drum, Last95Max, Last95Freq);
+					printf("  %02X / %02hX at %5u Hz", 1 + Last95Drum, Last95Max, Last95Freq);
 				else if (Show95Cmds == 0x03)
-					printf("  %02hX / %02hX at %4.1f KHz", 1 + Last95Drum, Last95Max,
+					printf("  %02X / %02hX at %4.1f KHz", 1 + Last95Drum, Last95Max,
 							Last95Freq / 1000.0);
 			}
 			//printf("  %u / %u", multipcm_get_channels(0, NULL), 28);

--- a/VGMPlay/chips/mamedef.h
+++ b/VGMPlay/chips/mamedef.h
@@ -49,7 +49,9 @@ typedef INT32 stream_sample_t;
 #else
 #define INLINE	static inline
 #endif
+#ifndef M_PI
 #define M_PI	3.14159265358979323846
+#endif
 
 #ifdef _DEBUG
 #define logerror	printf

--- a/VGMPlay/vgm2pcm.c
+++ b/VGMPlay/vgm2pcm.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
 
 	sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
 	if (sampleBuffer == NULL) {
-		fprintf(stderr, "vgm2pcm: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+		fprintf(stderr, "vgm2pcm: error: failed to allocate %lu bytes of memory\n", SAMPLESIZE * SampleRate);
 		return 1;
 	}
 

--- a/VGMPlay/vgm2wav.c
+++ b/VGMPlay/vgm2wav.c
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
 
 	sampleBuffer = (WAVE_16BS*)malloc(SAMPLESIZE * SampleRate);
 	if (sampleBuffer == NULL) {
-		fprintf(stderr, "vgm2wav: error: failed to allocate %u bytes of memory\n", SAMPLESIZE * SampleRate);
+		fprintf(stderr, "vgm2wav: error: failed to allocate %lu bytes of memory\n", SAMPLESIZE * SampleRate);
 		return 1;
 	}
 


### PR DESCRIPTION
Fix all clang-6.0.0 -Wformat warnings.
Do not redefine M_PI if the system already has it.

VGMPlay will soon be available as an OpenBSD package. These are the little tweaks we are using to make the C compiler (clang-6.0.0) happy. Clang does complain about a few more trivial things which I can send later if desired.

Thanks!