### PR TITLE
Fix heap overflow in VGMPlayUI

### DIFF
--- a/VGMPlay/VGMPlayUI.c
+++ b/VGMPlay/VGMPlayUI.c
@@ -757,17 +757,12 @@ static void WinNT_Check(void)
 static char* GetAppFileName(void)
 {
 	char* AppPath;
-	int RetVal;
 	
-	AppPath = (char*)malloc(MAX_PATH * sizeof(char));
+	AppPath = calloc(MAX_PATH, sizeof(char));
 #ifdef WIN32
-	RetVal = GetModuleFileName(NULL, AppPath, MAX_PATH);
-	if (! RetVal)
-		AppPath[0] = '\0';
+	GetModuleFileName(NULL, AppPath, MAX_PATH - 1);
 #else
-	RetVal = readlink("/proc/self/exe", AppPath, MAX_PATH);
-	if (RetVal == -1)
-		AppPath[0] = '\0';
+	readlink("/proc/self/exe", AppPath, MAX_PATH - 1);
 #endif
 	
 	return AppPath;


### PR DESCRIPTION
On Linux, "readlink() does not append a null byte to buf" READLINK(2)
which means that strrchr on VGMPlayUI.c:331 will consistently attempt
to read past the buffer, as long as the memory pointed to hasn't been
zeroed out by something else in the past, before it was allocated.

GetModuleFileName on Windows XP, if the length of the path exceeds
nSize, then "The string is truncated to nSize characters and is not
null-terminated."
https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamea

This commit fixes the issue by using calloc to zero out the string,
and then lowering the size value by one, so that on linux the string
is always terminated, and on Windows XP it will still be terminated
even if it gets truncated.