### PR TITLE
Implement MPRIS Pause method

### DIFF
--- a/VGMPlay/dbus.c
+++ b/VGMPlay/dbus.c
@@ -1153,8 +1153,8 @@ static DBusHandlerResult DBusHandler(DBusConnection* connection, DBusMessage* me
 
         return DBUS_HANDLER_RESULT_HANDLED;
     }
-    //Respond to Play/PlayPause
-    else if(dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "Play") || dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "PlayPause"))
+    //Respond to Play/PlayPause/Pause
+    else if(dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "Play") || dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "PlayPause") || dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "Pause"))
     {
         DBusEmptyMethodResponse(connection, message);
         evtCallback(MMKEY_PLAY);

--- a/VGMPlay/dbus.c
+++ b/VGMPlay/dbus.c
@@ -1161,6 +1161,12 @@ static DBusHandlerResult DBusHandler(DBusConnection* connection, DBusMessage* me
 
         return DBUS_HANDLER_RESULT_HANDLED;
     }
+    // Stop is currently a stub
+    else if(dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "Stop"))
+    {
+        DBusEmptyMethodResponse(connection, message);
+        return DBUS_HANDLER_RESULT_HANDLED;
+    }
     //Respond to Previous
     else if(dbus_message_is_method_call(message, DBUS_MPRIS_PLAYER, "Previous"))
     {


### PR DESCRIPTION
Looks like I initially forgot to implement it, rendering KDE unable to pause.
Just like Play, it's bound to PlayPause, which shouldn't be much of an issue for now.