### PR TITLE
fix the find command to work with vgm and vgz when play from zip

### DIFF
--- a/VGMPlay/vgm-player
+++ b/VGMPlay/vgm-player
@@ -318,7 +318,7 @@ if [ "$_unpack" = true ]; then
     _m3u_stub=$(command find . -iname '*.m3u' -print 2> /dev/null | head -n 1 | sed -e 's/^.\///')
     if [ -z "$_m3u_stub" ]; then
         _m3u_stub="List.m3u"
-        command find . -iname '*.vgm' -o -iname '*.vgz' -print | sed -e 's/^.\///' > "$_m3u_stub" 2> /dev/null
+        command find . -iname '*.vg[mz]' -print | sort | sed -e 's/^.\///' > "$_m3u_stub" 2> /dev/null
     fi
     _music_file="$PWD/$_m3u_stub"
 fi


### PR DESCRIPTION
The find command use in vgm-player can't work with the vgm file because it use the or operator between 2 filename.

cf `man find`
> Please note that -a when specified implicitly (for example by two tests appearing without an explicit operator between them) or explicitly has higher  precedence  than  -o.   This means that find . -name afile -o -name bfile -print will never print afile.

This fix use a Shell Pattern Matching.