### PR TITLE
Don't display full paths in the File Name field

### DIFF
--- a/VGMPlay/VGMPlayUI.c
+++ b/VGMPlay/VGMPlayUI.c
@@ -272,6 +272,7 @@ int main(int argc, char* argv[])
 	const char* FileExt;
 	UINT8 CurPath;
 	UINT32 ChrPos;
+	char* DispFileName;
 	
 	// set locale to "current system locale"
 	// (makes Unicode characters (like umlauts) work under Linux and fixes some
@@ -490,7 +491,12 @@ int main(int argc, char* argv[])
 	{
 		// The argument should already use the ANSI codepage.
 		strcpy(VgmFileName, argv[argbase]);
-		printf("%s\n", VgmFileName);
+		DispFileName = GetLastDirSeparator(VgmFileName);
+		if(DispFileName && strlen(DispFileName) > 2)
+			DispFileName++;
+		else
+			DispFileName = VgmFileName;
+		printf("%s\n", DispFileName);
 	}
 	if (! strlen(VgmFileName))
 		goto ExitProgram;


### PR DESCRIPTION
This commit makes the "File Name" field in the player only show the file name and not the full path if passed as an argument.

![vgmplayfn](https://user-images.githubusercontent.com/6003656/71636911-542d3780-2c40-11ea-836f-f04fe266645e.png)

Instead of:
![vgmplayfpath](https://user-images.githubusercontent.com/6003656/71636913-55f6fb00-2c40-11ea-8c36-81699231300b.png)
