### PR TITLE
Fix builds for old Linux distros

### DIFF
--- a/VGMPlay/Stream.c
+++ b/VGMPlay/Stream.c
@@ -2,7 +2,7 @@
 //
 
 // Thanks to nextvolume for NetBSD support
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdio.h>
 #include "stdbool.h"
 #include <stdlib.h>

--- a/VGMPlay/VGMPlay.c
+++ b/VGMPlay/VGMPlay.c
@@ -25,7 +25,7 @@
 //#define VGM_LITTLE_ENDIAN	// enable optimizations for Little Endian systems
 //#define VGM_BIG_ENDIAN	// enable optimizations for Big Endian systems
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/VGMPlay/VGMPlayUI.c
+++ b/VGMPlay/VGMPlayUI.c
@@ -4,7 +4,7 @@
 //		 if linked to msvcrt.lib, the following project setting is important:
 //		 C/C++ -> Code Generation -> Runtime libraries: Multithreaded DLL
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/VGMPlay/VGMPlay_AddFmts.c
+++ b/VGMPlay/VGMPlay_AddFmts.c
@@ -1,5 +1,5 @@
 // VGMPlay_AddFmts.c: C Source File for playback of additional non-VGM formats
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/VGMPlay/dbus.c
+++ b/VGMPlay/dbus.c
@@ -12,7 +12,7 @@ LDFLAGS=$(pkg-config --libs dbus-1)
 They weren't lying when they said that using libdbus directly signs you up for some pain...
 */
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/VGMPlay/vgm2pcm.c
+++ b/VGMPlay/vgm2pcm.c
@@ -1,4 +1,4 @@
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Old distros seem to have trouble with _DEFAULT_SOURCE, so instead of additionally defining _BSD_SOURCE and _POSIX_C_SOURCE, use _GNU_SOURCE instead as it implies both and more.

https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html