### PR TITLE
Improve BSD support

### DIFF
--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -266,8 +266,7 @@ vgmplay:	$(EMUOBJS) $(MAINOBJS) $(VGMPLAY_OBJS)
 ifneq ($(WINDOWS), 1)
 ifneq ($(MACOSX), 1)
 	@echo Generating xdg desktop entry
-	@cp xdg/vgmplay.desktop.in xdg/vgmplay.desktop
-	@sed -i "s/@BIN_PATH@/$(subst /,\/,$(DESTDIR)$(PREFIX)/bin/)/" xdg/vgmplay.desktop
+	@sed "s/@BIN_PATH@/$(subst /,\/,$(DESTDIR)$(PREFIX)/bin/)/" xdg/vgmplay.desktop.in > xdg/vgmplay.desktop
 endif
 endif
 	@echo Linking vgmplay ...

--- a/VGMPlay/Stream.c
+++ b/VGMPlay/Stream.c
@@ -9,28 +9,26 @@
 
 #ifdef WIN32
 #include <windows.h>
+#ifdef USE_LIBAO
+#error "Sorry, but this doesn't work yet!"
+#endif // USE_LIBAO
 #else
+#include <unistd.h>
 #include <limits.h>
-
 #include <sys/ioctl.h>
 #include <fcntl.h>
-#ifdef __NetBSD__
-#include <sys/audioio.h>
-#elif defined(__APPLE__) || defined(__OpenBSD__)
-// nothing
-#else
-#include <linux/soundcard.h>
-#endif
-#include <unistd.h>
-
-#endif
 
 #ifdef USE_LIBAO
-#ifdef WIN32
-#error "Sorry, but this doesn't work yet!"
-#endif
 #include <ao/ao.h>
-#endif
+#else
+#ifdef __NetBSD__
+#include <sys/audioio.h>
+#elif defined(__linux__)
+#include <linux/soundcard.h>
+#endif // __NETBSD__
+#endif // USE_LIBAO
+
+#endif // WIN32
 
 #include "chips/mamedef.h"	// for UINT8 etc.
 #include "VGMPlay.h"	// neccessary for VGMPlay_Intf.h

--- a/VGMPlay/VGMPlay_AddFmts.c
+++ b/VGMPlay/VGMPlay_AddFmts.c
@@ -11,6 +11,7 @@
 //#include <windows.h>
 void __stdcall Sleep(unsigned int dwMilliseconds);
 #else
+#include <unistd.h>
 #define	Sleep(msec)		usleep(msec * 1000)
 #endif
 


### PR DESCRIPTION
This PR fixes a few issues that prevented vgmplay from compiling without errors under FreeBSD (and possibly others).

Previously `#include <linux/soundcard.h>` would be included as long as the OS wasn't macOS/NetBSD/OpenBSD, causing problems for other BSDs, and unnecessarily be included for Linux libao builds.
Now, that, and the NetBSD equivalent are only included if libao isn't used (as libao works on both NetBSD and FreeBSD if desired).

Additionally, BSD sed isn't compatible with GNU sed, so instead of copying the file and using `sed -i` to modify it in place, sed is now ran on the original file and the output is piped to the new file.

Finally, there was a missing unistd.h include that would result in an undefined warning for usleep.