### PR TITLE
Fix a linking error with GCC 10

### DIFF
--- a/VGMPlay/VGMPlay_AddFmts.c
+++ b/VGMPlay/VGMPlay_AddFmts.c
@@ -118,7 +118,7 @@ extern INT32 VGMSmplPlayed;
 extern INT32 VGMSampleRate;
 extern UINT32 BlocksSent;
 extern UINT32 BlocksPlayed;
-bool VGMEnd;
+extern bool VGMEnd;
 extern bool EndPlay;
 extern bool PausePlay;
 extern bool FadePlay;


### PR DESCRIPTION
GCC 10 made redefining globals more obvious...