### PR TITLE
fix build errors on osx

### DIFF
--- a/VGMPlay/Makefile
+++ b/VGMPlay/Makefile
@@ -244,7 +244,7 @@ EMUOBJS = \
 	$(EMUOBJ)/ym2413_opl.o
 VGMPLAY_OBJS = \
 	$(OBJ)/VGMPlayUI.o
- 
+
 ifeq ($(USE_DBUS), 1)
 	VGMPLAY_OBJS += $(OBJ)/dbus.o
 else ifeq ($(WINDOWS), 1)
@@ -304,7 +304,7 @@ clean:
 	@echo Done.
 
 # Thanks to ZekeSulastin and nextvolume for the install and uninstall routines.
-install:	vgmplay
+install:	all
 	install -m 755 vgmplay $(DESTDIR)$(PREFIX)/bin/vgmplay
 	install -m 755 vgm2pcm $(DESTDIR)$(PREFIX)/bin/vgm2pcm
 	install -m 755 vgm2wav $(DESTDIR)$(PREFIX)/bin/vgm2wav


### PR DESCRIPTION
Without this change I get these errors when building: 
```
$ make install MACOSX=1 DISABLE_HWOPL_SUPPORT=1
Compiling chips/262intf.c ...
<omitted output for brevity>
Linking vgmplay ...
Done.
install -m 755 vgmplay /usr/local/bin/vgmplay
install -m 755 vgm2pcm /usr/local/bin/vgm2pcm
install: vgm2pcm: No such file or directory
make: *** [install] Error 71
```
See the full log output: https://gist.github.com/dasl-/65649a1ac9f7ee53a99544bd174b7c3d

With these changes, it builds successfully. See the full log: https://gist.github.com/dasl-/306b9abba0b4f6c154c7974908945ff8